### PR TITLE
Fix the max-age regex

### DIFF
--- a/lib/requestManager.js
+++ b/lib/requestManager.js
@@ -86,7 +86,7 @@ RequestManager.prototype = {
         this.handleError(error, item, req);
       } else {
         if(res && res.headers && res.headers['cache-control']) {
-          cacheControl = res.headers['cache-control'].match(/max-age=(.*),/) || [];
+          cacheControl = res.headers['cache-control'].match(/max-age=([\d]+)\b/) || [];
           ttl = cacheControl.length > 1 ? parseInt(cacheControl[1]) * 1000 : ttl;
         }
         cache.put(req.url, {error: error, item: item}, ttl);

--- a/test/requestManagerCaching.spec.js
+++ b/test/requestManagerCaching.spec.js
@@ -91,11 +91,11 @@ describe('Request Manager Cache', function () {
     var req = { url: 'http://www.google.com',
       notifyInProgress: jasmine.createSpy(),
       notifyCompleted: jasmine.createSpy(),
-      logger: MOCK_LOGGER 
+      logger: MOCK_LOGGER
     };
     var res = {
       headers: {
-        'cache-control': 'max-age=1000, s-maxage=1000'
+        'cache-control': 's-maxage=234, max-age=1000'
       }
     };
 
@@ -179,7 +179,7 @@ it('doesn\'t save an erroneous response in cache',
     };
     var res = {
       headers: {
-        'cache-control': 'max-age=1000, s-maxage=1000'
+        'cache-control': 'max-age=1000, s-maxage=1000, public'
       }
     };
 


### PR DESCRIPTION
Ie. maxage should only be an integer separated by a word boundary, especially as you are feeding it to parseInt, which will produce `NaN` if it doesn't find a number.

/cc @adgad 

Sorry about the whitespace, but the files were saved with dos line endings at some point. I've converted them to unix.
