### PR TITLE
Reduce max retries from 50 to 10

### DIFF
--- a/config/general.json
+++ b/config/general.json
@@ -1,7 +1,7 @@
 {
     "maxNotificationsPerCall": 200,
     "maxConcurrentRequests": 10,
-    "maxRetries": 50,
+    "maxRetries": 10,
     "defaultDelayMilliseconds": 1,
     "retryDelayMilliseconds": 10,
     "defaultCacheTTLMilliseconds": 120000,


### PR DESCRIPTION
Currently, when a single request to the CAPI fails, it retries 50 times. For genuine failures (i.e. CAPI is down), this will take quite a long time. With exponential backoff, a request shouldn't need to retry more than a couple of times. Hence, reducing this to a more reasonable 10.
