### PR TITLE
search parameters overrideable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Or retrieve a collection of articles via a search term,
         console.log(articles);
       })
 
+To request more results than the default (`5`) pass in a second parameter with the number required.
+
+To override the [default `resultContext` config](https://github.com/Financial-Times/ft-api-client/blob/v3/lib/v1/search.js#L4) sent to the search api a third parameter can be passed, which should be an object conforming to the structure expected by `resultContext`. The properties in this object will override the defaults. For properties which are arrays prefixing the property name with '+' will concatenate the properties passed to the default set e.g. `'+aspects': ['example']` will add `'example'` to th edefault list of aspects. 

--- a/lib/v1/complexSearch.js
+++ b/lib/v1/complexSearch.js
@@ -96,14 +96,13 @@ function complexSearch(requestBody){
        callback = curry(onResponse, resolve, reject);
 
         debug('requested %s', endpoint);
-        request({
+        request.post({
             url: endpoint,
             qs: {
                 apiKey: self.apiKey,
 		'feature.blogposts': 'on'
             },
             headers: self.headers,
-            method: 'post',
             body: JSON.stringify(requestBody),
             timeout: 2000
         }, callback);

--- a/lib/v1/requestHandler.js
+++ b/lib/v1/requestHandler.js
@@ -19,7 +19,7 @@ module.exports = function (opts) {
 			return resolve(cachedItem);
 		}
 
-		request({
+		request.get({
 		        url: endpoint,
 		        qs: {
 		            apiKey: self.apiKey,

--- a/lib/v1/search.js
+++ b/lib/v1/search.js
@@ -2,15 +2,15 @@
 var v1      = require('./');
 
 var defaultResultContext = {
-    "aspects" : ["editorial","images","lifecycle","location","master","metadata","nature","summary","title"],
-    "maxResults": 5,
-    "offset":0,
-    "contextual": true,
-    "highlight": false,
-    "facets":{
-        "names":["organisations", "regions", "sections", "topics"],
-        "maxElements":5,
-        "minThreshold":100
+    aspects: ["editorial","images","lifecycle","location","master","metadata","nature","summary","title"],
+    maxResults: 5,
+    offset: 0,
+    contextual: true,
+    highlight: false,
+    facets:{
+        names:["organisations", "regions", "sections", "topics"],
+        maxElements: 5,
+        minThreshold: 100
     }
 };
 
@@ -73,11 +73,11 @@ module.exports = function (term, quantity, overrides) {
     var self = this;
    
     var searchBodyTemplate = {
-        "queryString":term,
-        "queryContext":{
-            "curations":["ARTICLES", "BLOGS"]
+        queryString: term,
+        queryContext: {
+            curations: ["ARTICLES", "BLOGS"]
         },
-        "resultContext": resultContext
+        resultContext: resultContext
     };
 
     return v1.complexSearch.call(self, searchBodyTemplate);

--- a/test/apiSpec.js
+++ b/test/apiSpec.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var expect  = require("chai").expect;
-var nock    = require("nock");
-var sinon   = require("sinon");
-var util    = require("util");
-var fs      = require("fs");
+var expect  = require('chai').expect;
+var nock    = require('nock');
+var sinon   = require('sinon');
+var util    = require('util');
+var fs      = require('fs');
+var request = require('request')
 
 require('es6-promise').polyfill();
 
-var ft      = require("../lib/api")('123');
+var ft      = require('../lib/api')('123');
 
 describe('API', function(){
 
@@ -72,7 +73,7 @@ describe('API', function(){
             return '*';
         });
         nock(host).filteringRequestBody(spy).post(util.format(searchPath, '123'), '*').reply(200, fixtures.search);
-        ft.search("Portillo's teeth removed to boost pound", 99)
+        ft.search('Portillo\'s teeth removed to boost pound', 99)
           .then(function () {
             expect(spy.calledOnce).to.true;
             expect(JSON.parse(spy.firstCall.args[0]).resultContext.maxResults).to.equal(99);
@@ -156,4 +157,37 @@ describe('API', function(){
 
             }, done);
     });
+
+    it('Should request different fields if user specifies', function () {
+        sinon.stub(request, 'post');
+        ft.search('Climate change', 20, {
+            offset: 10,
+            highlight: true,
+            aspects: ['testterm1','testterm2'],
+            facets: {
+                '+names': ['testterm3']
+            }
+        });
+        var resultContext = JSON.parse(request.post.lastCall.args[0].body).resultContext;
+        console.log(JSON.stringify(resultContext.aspects, null, '\t'));
+
+        expect(resultContext.aspects).to.eql([
+            "testterm1",
+            "testterm2"
+        ]);
+        expect(resultContext.maxResults).to.equal(20);
+        expect(resultContext.offset).to.equal(10);
+        expect(resultContext.highlight).to.be.true;
+        expect(resultContext.facets.names).to.eql([
+            "organisations",
+            "regions",
+            "sections",
+            "topics",
+            "testterm3"
+        ]);
+
+        request.post.restore();
+    });
+
+
 });


### PR DESCRIPTION
Code is a little bit convoluted (owing to the fact that search config is not just a flat object), but the end effect is that passing in a third parameter of e.g. 

```
{
  highlight: true, 
  facets: {
    minThreshold: 50, 
    names: ["regions']
  }
}
```

will override as you'd expect it to.

In addition if the key `names` was replaced with `'+names'` then the array woudl be concatenated with the default list of names.

If this looks good I'll write tests and document properly

@richard-still-ft 
