### PR TITLE
Set property directly, rather than using defineProperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
 - make test
 node_js:
 - '0.10'
-- '0.12'
+- '0.12.2'
 before_deploy:
 - npm-prepublish --verbose
 deploy:

--- a/lib/models/article.js
+++ b/lib/models/article.js
@@ -47,6 +47,9 @@ Article.prototype.paragraphs = function (to, from, options) {
 	return $('p').slice(to, from);
 };
 
+// TODO: move the following out of defineProperty and just set `this` directly
+// https://github.com/Financial-Times/ft-api-client/pull/136
+
 /**
  * Returns a list of inbound links to other FT articles contained within the article body
  */

--- a/lib/models/article.js
+++ b/lib/models/article.js
@@ -24,7 +24,16 @@ Article.prototype.parse = function (obj) {
 	this.id = obj.item.id;
 	this.raw = obj;
 
-	if (!this.raw.item.body) return;
+	if (this.raw.item.body) {
+		var html = this.raw.item.body.body;
+		try {
+			this.body = dom.removeNonArticleLinks(dom.fixRelativeLinks(dom.removeEmptyParagraphs(html)));
+		} catch (e) {
+			this.body = '<p>Error parsing this article.</p>';
+		}
+	} else {
+		this.body = '';
+	}
 };
 
 /**
@@ -466,25 +475,6 @@ Object.defineProperty(Article.prototype, 'quotes', {
 		} else {
 			return [];
 		}
-	}
-});
-
-/**
- * The article body as HTML.
- */
-Object.defineProperty(Article.prototype, 'body', {
-	get: function () {
-
-		var html = this.raw.item.body.body;
-
-		try {
-			return dom.removeNonArticleLinks(dom.fixRelativeLinks(dom.removeEmptyParagraphs(html)));
-		} catch (e) {
-			// console.error('Error parsing article body', e);
-			return '<p>Error parsing this article.</p>';
-		}
-
-
 	}
 });
 


### PR DESCRIPTION
Causing a big performance hit, e.g. every time `this.body` was being called, the function was run.

Starting with just this, but all the properties in here should set `this` directly

Using Engels as a test,

### Before

```
$ siege -c 12 -t 20s http://localhost:3002/uk
...
Transactions:		          40 hits
Availability:		      100.00 %
Elapsed time:		       19.40 secs
Data transferred:	       12.02 MB
Response time:		        4.67 secs
Transaction rate:	        2.06 trans/sec
Throughput:		        0.62 MB/sec
Concurrency:		        9.62
Successful transactions:          40
Failed transactions:	           0
Longest transaction:	        6.59
Shortest transaction:	        1.73
```

### After

```
$ siege -c 12 -t 20s http://localhost:3002/uk
...
Transactions:		          91 hits
Availability:		      100.00 %
Elapsed time:		       19.48 secs
Data transferred:	       27.36 MB
Response time:		        2.01 secs
Transaction rate:	        4.67 trans/sec
Throughput:		        1.40 MB/sec
Concurrency:		        9.39
Successful transactions:          91
Failed transactions:	           0
Longest transaction:	        2.80
Shortest transaction:	        1.21
```